### PR TITLE
Add MkDocs with Material theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,19 +5,19 @@
 [![Docker](https://img.shields.io/badge/Docker-Ready-blue.svg)](https://docker.com)
 [![Contributions Welcome](https://img.shields.io/badge/contributions-welcome-orange.svg)](CONTRIBUTING.md)
 
-> A curated list of **49 awesome open-source, self-hosted tools** with ready-to-use Docker Compose configurations. Take control of your data and infrastructure with these free alternatives to popular SaaS services.
+> A curated list of **50 awesome open-source, self-hosted tools** with ready-to-use Docker Compose configurations. Take control of your data and infrastructure with these free alternatives to popular SaaS services.
 
 All tools are production-ready, include latest 2024 versions, and come with comprehensive documentation and setup instructions.
 
 ## 📋 Quick Index
 
-**Total Tools: 49** | **Categories: 22** | **Port Range: 8300-8641**
+**Total Tools: 50** | **Categories: 22** | **Port Range: 8300-8641**
 
 ## 🗂️ **Directory Structure**
 
 ```
 tools/
-├── development/           # 20 Development & Infrastructure Tools
+├── development/           # 21 Development & Infrastructure Tools
 │   ├── ci-cd/            # Jenkins
 │   ├── git-repositories/ # GitLab, Gitea
 │   ├── monitoring/       # Prometheus, Grafana, SigNoz, Sentry, Jaeger
@@ -27,7 +27,7 @@ tools/
 │   ├── security/         # Vaultwarden, Keycloak
 │   ├── messaging-streaming/ # Kafka
 │   ├── workflow-automation/ # Temporal, Huginn, n8n
-│   ├── documentation/    # BookStack
+│   ├── documentation/    # BookStack, MkDocs
 │   └── media-management/ # Jellyfin, PhotoPrism
 └── business/             # 29 Business & Marketing Tools
     ├── cms-publishing/   # WordPress, Ghost, Strapi, Drupal
@@ -45,7 +45,7 @@ tools/
 
 ---
 
-## 🔧 **Development & Infrastructure Tools (20)**
+## 🔧 **Development & Infrastructure Tools (21)**
 
 ### **CI/CD & Automation**
 | Tool | Location | Port(s) | Description |
@@ -104,6 +104,7 @@ tools/
 | Tool | Location | Port(s) | Description |
 |------|----------|---------|-------------|
 | **BookStack** | `development/documentation/bookstack/` | 8400 | Wiki-style documentation |
+| **MkDocs** | `development/documentation/mkdocs-material/` | 8409 | Static site generator with Material theme |
 
 ### **Media Management**
 | Tool | Location | Port(s) | Description |
@@ -229,7 +230,7 @@ Tools for software development:
 - GitLab/Gitea (Code Management)
 - Jenkins (CI/CD)
 - Prometheus + Grafana (Monitoring)
-- BookStack (Documentation)
+- BookStack or MkDocs (Documentation)
 - Nextcloud (File Sharing)
 
 ### **Marketing Agency**
@@ -267,7 +268,7 @@ Comprehensive business solution:
 
 ## 📊 Statistics
 
-- **Total Tools:** 49
+- **Total Tools:** 50
 - **Categories:** 24
 - **Docker Images:** Latest 2024 versions
 - **Database Systems:** PostgreSQL, MySQL, MariaDB, SQLite, Redis

--- a/development/documentation/mkdocs-material/README.md
+++ b/development/documentation/mkdocs-material/README.md
@@ -1,0 +1,31 @@
+# MkDocs with Material Theme - Static Site Generator
+
+MkDocs is a fast, simple static site generator that's geared towards building project documentation. This setup uses the popular **Material for MkDocs** theme.
+
+## Features
+- Write documentation in Markdown
+- Live preview with hot reloading
+- Built-in search and navigation
+- Responsive Material Design theme
+
+## Quick Start
+1. Add your Markdown files to the `docs/` directory.
+2. Run the service:
+   ```bash
+   docker compose up -d
+   ```
+3. Open `http://localhost:8409` in your browser.
+
+## Configuration
+- Port: **8409** (maps to internal port 8000)
+- Base image: `squidfunk/mkdocs-material`
+- Documentation files mounted from `./docs`
+
+## Useful Commands
+- `mkdocs serve` – start a local preview server
+- `mkdocs build` – build the static site into the `site/` directory
+
+## License
+
+MIT License
+

--- a/development/documentation/mkdocs-material/docker-compose.yml
+++ b/development/documentation/mkdocs-material/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  mkdocs:
+    image: squidfunk/mkdocs-material:latest
+    container_name: mkdocs-material
+    ports:
+      - "8409:8000"
+    volumes:
+      - ./docs:/docs
+    command: mkdocs serve -a 0.0.0.0:8000
+    restart: unless-stopped
+
+volumes:
+  docs:

--- a/development/documentation/mkdocs-material/docs/index.md
+++ b/development/documentation/mkdocs-material/docs/index.md
@@ -1,0 +1,4 @@
+# Welcome to MkDocs
+
+This is a placeholder page. Add your documentation Markdown files here.
+


### PR DESCRIPTION
## Summary
- add MkDocs with Material theme under development documentation tools
- document MkDocs usage and configuration
- include placeholder docs
- list MkDocs in the README and update tool counts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844101df17483329c48cf0d17c8b9e1